### PR TITLE
Feature/#249 simplify expenses

### DIFF
--- a/Spbs.Ui/Features/BankIntegration/ImportExpenses/ImportExpensesPage.razor
+++ b/Spbs.Ui/Features/BankIntegration/ImportExpenses/ImportExpensesPage.razor
@@ -18,7 +18,7 @@ else
                 {
                     <MudTooltip Delay="600" Text="Toggle include status of selection">
                         <MudButton OnClick="() => ToggleInclude(_selectedTransactions)" Color="Color.Primary">
-                        @(_includeAllSwitchValue ? "Include Selection" : "Exclude Selection")
+                            @(_includeAllSwitchValue ? "Include Selection" : "Exclude Selection")
                         </MudButton>
                     </MudTooltip>
                 }
@@ -54,13 +54,29 @@ else
             <Columns>
                 <SelectColumn T="ImportExpensesViewModel"/>
 
-                <PropertyColumn Property="x => x.TransactionAmount.Amount"/>
-                <PropertyColumn Property="x => x.TransactionAmount.Currency"/>
+                <PropertyColumn T="ImportExpensesViewModel" TProperty="double" Title="Amount">
+                    <CellTemplate>
+                        @context.Item.TransactionAmount.Amount
+                    </CellTemplate>
+                    <EditTemplate>
+                        <MudNumericField @bind-Value="@context.Item.TransactionAmount.Amount" Label="Amount" Variant="Variant.Text" Min="0.0"/>
+                    </EditTemplate>
+                </PropertyColumn>
+
+                <PropertyColumn T="ImportExpensesViewModel" TProperty="string" Title="Currency">
+                    <CellTemplate>
+                        @context.Item.TransactionAmount.Currency
+                    </CellTemplate>
+                    <EditTemplate>
+                        <MudTextField @bind-Value="@context.Item.TransactionAmount.Currency" Label="Currency" Variant="Variant.Text" />
+                    </EditTemplate>
+                </PropertyColumn>
+
                 <PropertyColumn Property="x => x.ValueDate" Title="Date" IsEditable="false"/>
 
                 <PropertyColumn Property="x => x.RemittanceInformationUnstructured" Title="Name"/>
 
-                <TemplateColumn T="ImportExpensesViewModel" CellClass="d-flex justify-end">
+                <TemplateColumn IsEditable="false" T="ImportExpensesViewModel" CellClass="d-flex justify-end">
                     <CellTemplate>
                         <MudStack Row="true">
                             @if (context.Item.IncludeInImport)
@@ -71,7 +87,7 @@ else
                             {
                                 <MudChip Color="Color.Secondary">Exclude from Import</MudChip>
                             }
-                            
+
                             @if (context.Item.IsPending)
                             {
                                 <MudChip Color="Color.Dark">Transaction Pending</MudChip>

--- a/Spbs.Ui/Features/BankIntegration/ImportExpenses/Mapping/ImportExpensesViewModelMapper.cs
+++ b/Spbs.Ui/Features/BankIntegration/ImportExpenses/Mapping/ImportExpensesViewModelMapper.cs
@@ -25,23 +25,9 @@ public class ImportExpensesViewModelMapper : Profile
             .ForMember(e => e.Venue, opt => opt.MapFrom(vm => vm.RemittanceInformationUnstructured))
             .ForMember(e => e.Description, opt => opt.MapFrom(vm => "Expense imported with id " + vm.TransactionId))
             .ForMember(e => e.Name, opt => opt.MapFrom(vm => vm.RemittanceInformationUnstructured))
+            .ForMember(e => e.Total, opt => opt.MapFrom(vm => vm.TransactionAmount.Amount))
+            
             .ForMember(e => e.Category, opt => opt.Ignore())
-            
-            // Untill we can support expenses with a total but no expense items.
-            .ForMember(e => e.Items, opt => 
-                opt.MapFrom(vm =>
-                    new List<ExpenseItem>
-                    {
-                        new ExpenseItem
-                        {
-                            Name = vm.RemittanceInformationUnstructured,
-                            Price = vm.TransactionAmount.Amount,
-                            Quantity = 1
-                        }
-                    }))
-            .ForMember(e => e.Total, opt => opt.Ignore())
-            .ForMember(e => e._total, opt => opt.Ignore())
-            
             .ForMember(e => e.Id, opt => opt.Ignore())
             .ForMember(e => e.Recurring, opt => opt.Ignore())
             .ForMember(e => e.Tags, opt => opt.Ignore())

--- a/Spbs.Ui/Features/BankIntegration/ImportExpenses/Mapping/ImportExpensesViewModelMapper.cs
+++ b/Spbs.Ui/Features/BankIntegration/ImportExpenses/Mapping/ImportExpensesViewModelMapper.cs
@@ -27,6 +27,7 @@ public class ImportExpensesViewModelMapper : Profile
             .ForMember(e => e.Name, opt => opt.MapFrom(vm => vm.RemittanceInformationUnstructured))
             .ForMember(e => e.Total, opt => opt.MapFrom(vm => vm.TransactionAmount.Amount))
             
+            .ForMember(e => e.Items, opt => opt.Ignore())
             .ForMember(e => e.Category, opt => opt.Ignore())
             .ForMember(e => e.Id, opt => opt.Ignore())
             .ForMember(e => e.Recurring, opt => opt.Ignore())

--- a/Spbs.Ui/Features/Expenses/Expense.cs
+++ b/Spbs.Ui/Features/Expenses/Expense.cs
@@ -46,8 +46,6 @@ public class Expense : ICosmosData
     [JsonProperty("tags")]
     public string? Tags { get; set; }
 
-    public double? _total;
-
     [JsonProperty("total")] 
     public double Total { get; set; }
 


### PR DESCRIPTION
Remove the dependency between the total field and the expense items in expenses. This is to make working with expenses less tedious, as you no longer need to specify each individual item on a receipt in order to get meaningful data.

Expens items are retained as an optional way for users to store details of an expense.